### PR TITLE
Overall cleanup

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -7,7 +7,7 @@
 
 namespace fs = std::filesystem;
 
-std::vector<fs::path> getDirectoryFiles(fs::path directory, const std::vector<std::string> extensions)
+std::vector<fs::path> getDirectoryFiles(const fs::path& directory, const std::vector<std::string>& extensions)
 {
     auto files = std::vector<fs::path>{};
 
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
     if (argc != 2)
     {
         std::cerr << "Usage: " << argv[0] << " [directory]" << std::endl;
-        return -1;
+        return 0;
     }
 
     const auto extensions = std::vector<std::string>{".jpg", ".png"};
@@ -48,31 +48,39 @@ int main(int argc, char** argv)
     if (!imageFiles.size())
     {
         std::cerr << "Failed to find image files from " << argv[1] << std::endl;
-        return -2;
+        return -1;
     }
 
-    txtratl::Atlas a;
+    txtratl::Atlas atlas;
 
-    for (const auto& file : imageFiles)
+    try
     {
-        std::cout << "Adding image: " << file.relative_path().string() << std::endl;
-        if (!a.addImage(file.relative_path()))
+        for (const auto& filepath : imageFiles)
         {
-            std::cerr << "Failed to add image: " << file.relative_path() << std::endl;
-            return -3;
+            std::cout << "Adding image: " << filepath.relative_path().string() << std::endl;
+            atlas.addImage(filepath.relative_path());
+        }
+
+        if (!atlas.packImages())
+        {
+            std::cerr << "Failed to pack images." << std::endl;
+            return -1;
+        }
+
+        if (!atlas.createAtlas("atlas.png", "atlas.txt"))
+        {
+            std::cerr << "Failed to create the atlas image and metadata" << std::endl;
+            return -1;
         }
     }
-
-    if (!a.packImages())
+    catch (std::exception const& e)
     {
-        std::cerr << "Failed to pack images." << std::endl;
-        return -4;
+        std::cerr << "Exception: " << e.what() << std::endl;
+        return -1;
     }
-
-    if (!a.createAtlas("atlas.png", "atlas.txt"))
+    catch (...)
     {
-        std::cerr << "Failed to create atlas image and metadata" << std::endl;
-        return -5;
+        std::cerr << std::endl;
     }
 
     return 0;

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -78,10 +78,6 @@ int main(int argc, char** argv)
         std::cerr << "Exception: " << e.what() << std::endl;
         return -1;
     }
-    catch (...)
-    {
-        std::cerr << std::endl;
-    }
 
     return 0;
 }

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+#include "txtratl/image.hpp"
+
+using namespace txtratl;
+
+TEST(Image, outOfBounds)
+{
+    auto image = Image(1, 1, 4);
+    EXPECT_NO_THROW(image.data(0, 0, 2));
+    EXPECT_THROW(image.data(2, 1, 1), std::out_of_range);
+}

--- a/txtratl/CMakeLists.txt
+++ b/txtratl/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(${PROJECT_NAME} STATIC ${SOURCES})
 target_include_directories(${PROJECT_NAME} PUBLIC include/)
 
 if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus /W4 /Wall)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus /W4 /Wall /wd4710 /wd4711)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     find_package(Threads REQUIRED)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -mssse3 -pthread)

--- a/txtratl/include/txtratl/atlas.hpp
+++ b/txtratl/include/txtratl/atlas.hpp
@@ -11,37 +11,45 @@ class Image;
 
 class Atlas
 {
-    static constexpr size_t ATLAS_MAX_SIDE = 24000; ///< Maximum side for atlas image in pixels
+    /// Maximum side length in pixels for the atlas image.
+    static constexpr size_t ATLAS_MAX_SIDE = 24000;
 
 public:
+    /// Constructor.
     explicit Atlas();
 
+    /// Default destructor.
     ~Atlas();
 
+    /// Copy constructor.
     Atlas(const Atlas& other);
+
+    /// Assignment operator.
     Atlas& operator=(Atlas rhs);
 
     /**
-     *   @brief  Adds an image file to be packed into the atlas.
+     * Adds an image file to be packed into the atlas.
      *
-     *   @param  filepath is a JPEG or PNG file to be added to the atlas.
-     *   @return true, if the image was added successfully.
+     * @param filepath is a JPEG or PNG file to be added to the atlas.
+     *
+     * @return true, if the image was added successfully.
      */
-    bool addImage(const std::filesystem::path& filepath);
+    void addImage(const std::filesystem::path& filepath);
 
     /**
-     *   @brief  Packs the added images into the atlas.
+     * Packs the images into the atlas.
      *
-     *   @return true, if packing was successfull
+     * @return true, if packing was successful.
      */
     bool packImages();
 
     /**
-     *   @brief  Creates an atlas image and a metadata file with image locations in atlas.
+     * Creates an atlas image and a metadata file with the image locations in atlas.
      *
-     *   @param  imageFilename is the destination JPEG file for the atlas
-     *   @param  metadataFilename is the destination TXT file for atlas metadata
-     *   @return true, if files were created successfully
+     * @param imageFilename is the destination image file for the atlas.
+     * @param metadataFilename is the destination text file for atlas metadata.
+     *
+     * @return true, if files were created successfully.
      */
     bool createAtlas(const std::filesystem::path& imageFilepath, const std::filesystem::path& metadataFilepath);
 
@@ -49,26 +57,21 @@ private:
     static constexpr size_t INVALID_ATLAS = 0;
 
     /**
-     *   @brief  Blits image rects into a given canvas according to rects coordinates.
+     * Blits image rects into a canvas according to rect coordinates.
      *
-     *   @param  canvas is the destination for image to be blit
-     *   @param  ir is the destination for image to be blit
-     *   @return true, if file was created successfully
+     * @param canvas is the destination for image to be blit.
+     * @param ir is the destination for image to be blit.
      */
-    bool blitImages(Image& canvas) const;
+    void blitImages(Image& canvas) const;
 
     /**
-     *   @brief  Writes atlas metadata into a text file.
+     * Writes atlas metadata into a text file.
      *
-     *   @param  outputFilename is the destination TXT file for atlas metadata
-     *   @return true, if file was created successfully
+     * @param outputFilename is the destination TXT file for atlas metadata.
+     *
+     * @return true, if the file was created successfully.
      */
     bool writeMetadata(const std::filesystem::path& outputFilepath) const;
-
-    bool isValid() const
-    {
-        return (mWidth != INVALID_ATLAS || mHeight != INVALID_ATLAS);
-    }
 
     class ImageRectImpl;
 

--- a/txtratl/include/txtratl/image.hpp
+++ b/txtratl/include/txtratl/image.hpp
@@ -10,15 +10,44 @@ namespace txtratl
 class Image
 {
 public:
+    /**
+     * Constructs an image object from a file.
+     *
+     * @param filepath The path to the image file to be loaded.
+     * @param deferLoading Does not load the image data and allocate memory for data, if true.
+     *
+     * @throws std::runtime_exception if the file access fails or the file in not an image file.
+     */
     explicit Image(const std::filesystem::path& filepath, bool deferLoading = false);
+
+    /**
+     * Constructs an image object and allocates the memory with the specified dimensions.
+     *
+     * @param width The width of the image.
+     * @param height The height of the image.
+     * @param channels The number of channels the image has (3 = RGB, 4 = RGBA).
+     *
+     * @throws std::runtime_exception if the file access fails or the file in not an image file.
+     */
     explicit Image(size_t width, size_t height, size_t channels);
 
-    void allocate(size_t width, size_t height, size_t channels);
+    /**
+     * Releases the image data owned by the object which can be reloaded.
+     */
     void release();
 
-    void loadinfo(const std::filesystem::path& filepath);
-
+    /**
+     * Loads the image file and allocates memory for the image data.
+     *
+     * @throws std::runtime_exception if the file access fails or the file in not an image file.
+     */
     void load();
+
+    /**
+     * Saves the image date to a PNG file.
+     *
+     * @throws std::runtime_exception if the file access fails or the file in not an image file.
+     */
     void save(const std::filesystem::path& filename) const;
 
     uint8_t* data(size_t x, size_t y, size_t channel) const;
@@ -27,10 +56,28 @@ public:
     size_t height() const;
     size_t width() const;
 
-    void blitImage(const Image& source, size_t x, size_t y);
+    void blitImage(const Image& source, size_t x, size_t y, bool releaseAfterUse = false);
 
 private:
+    /**
+     * Loads the image file including the image data.
+     *
+     * @param filepath is the path to the image file to be loaded.
+     *
+     * @throws std::runtime_exception if the file access fails or the file in not an image file.
+     */
     void load(const std::filesystem::path& filepath);
+
+    /**
+     * Loads the information from the image file without loading the image data.
+     *
+     * @param filepath is the path to the image file to be loaded.
+     *
+     * @throws std::runtime_exception if the file access fails or the file in not an image file.
+     */
+    void loadinfo(const std::filesystem::path& filepath);
+
+    void allocate(size_t width, size_t height, size_t channels);
 
     std::shared_ptr<std::vector<uint8_t>> mData = nullptr;
     std::filesystem::path mFilePath{};

--- a/txtratl/include/txtratl/image.hpp
+++ b/txtratl/include/txtratl/image.hpp
@@ -51,6 +51,15 @@ public:
      */
     void save(const std::filesystem::path& filename) const;
 
+    /**
+     * Gets a pointer to the specified pixel of the image's data.
+     *
+     * @param x The x coordinate of the image.
+     * @param y The y coordinate of the image.
+     * @param channels The channel of the image (R, G, B(, A)).
+     *
+     * @throws std::out_of_range if accessed outside of image's date (no validation for x, y, channel parameters).
+     */
     std::byte* data(size_t x, size_t y, size_t channel) const;
 
     size_t channels() const;

--- a/txtratl/include/txtratl/image.hpp
+++ b/txtratl/include/txtratl/image.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
 #include <memory>
 #include <vector>
@@ -50,7 +51,7 @@ public:
      */
     void save(const std::filesystem::path& filename) const;
 
-    uint8_t* data(size_t x, size_t y, size_t channel) const;
+    std::byte* data(size_t x, size_t y, size_t channel) const;
 
     size_t channels() const;
     size_t height() const;
@@ -79,7 +80,7 @@ private:
 
     void allocate(size_t width, size_t height, size_t channels);
 
-    std::shared_ptr<std::vector<uint8_t>> mData = nullptr;
+    std::shared_ptr<std::vector<std::byte>> mData = nullptr;
     std::filesystem::path mFilePath{};
 
     size_t mWidth = 0;

--- a/txtratl/include/txtratl/imageblit.hpp
+++ b/txtratl/include/txtratl/imageblit.hpp
@@ -7,25 +7,25 @@ namespace txtratl
 {
 
 /**
-*   @brief  Blits RGBA image (32-bit) into RGB image (24-bit) utilizing SSE3 intrinsics
-*
-*   @param  dest is a pointer to destination image
-*   @param  src is a pointer to source image
-*   @param  rows is the height of the source image
-*   @param  cols is the width of the source image
-*   @param  destCols is the width of the destination image
-*/
-void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t rows, const size_t cols, const size_t destCols);
+ * Blits RGBA image (32-bit) into RGB image (24-bit) utilizing SSE3 intrinsics.
+ *
+ * @param dest A pointer to destination image.
+ * @param src A pointer to source image.
+ * @param height The height of the source image.
+ * @param width The width of the source image.
+ * @param destCols The width of the destination image.
+ */
+void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destCols);
 
 /**
-*   @brief  Blits RGB image (24-bit) into RGBA image (32-bit) utilizing SSE3 intrinsics
-*
-*   @param  dest is a pointer to destination image
-*   @param  src is a pointer to source image
-*   @param  rows is the height of the source image
-*   @param  cols is the width of the source image
-*   @param  destCols is the width of the destination image
-*/
-void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t rows, const size_t cols, const size_t destCols);
+ * Blits RGB image (24-bit) into RGBA image (32-bit) utilizing SSE3 intrinsics.
+ *
+ * @param dest A pointer to destination image.
+ * @param src A pointer to source image.
+ * @param height The height of the source image.
+ * @param width The width of the source image.
+ * @param destCols Ihe width of the destination image.
+ */
+void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destCols);
 
 }; // namespace txtratl

--- a/txtratl/include/txtratl/imageblit.hpp
+++ b/txtratl/include/txtratl/imageblit.hpp
@@ -15,7 +15,7 @@ namespace txtratl
  * @param width The width of the source image.
  * @param destCols The width of the destination image.
  */
-void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destCols);
+void blitRGBAtoRGB_SSE3(std::byte* dest, const std::byte* src, const size_t width, const size_t height, const size_t destCols);
 
 /**
  * Blits RGB image (24-bit) into RGBA image (32-bit) utilizing SSE3 intrinsics.
@@ -26,6 +26,6 @@ void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, c
  * @param width The width of the source image.
  * @param destCols Ihe width of the destination image.
  */
-void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destCols);
+void blitRGBtoRGBA_SSE3(std::byte* dest, const std::byte* src, const size_t width, const size_t height, const size_t destCols);
 
 }; // namespace txtratl

--- a/txtratl/include/txtratl/imageblit.hpp
+++ b/txtratl/include/txtratl/imageblit.hpp
@@ -11,8 +11,8 @@ namespace txtratl
  *
  * @param dest A pointer to destination image.
  * @param src A pointer to source image.
- * @param height The height of the source image.
  * @param width The width of the source image.
+ * @param height The height of the source image.
  * @param destCols The width of the destination image.
  */
 void blitRGBAtoRGB_SSE3(std::byte* dest, const std::byte* src, const size_t width, const size_t height, const size_t destCols);
@@ -22,8 +22,8 @@ void blitRGBAtoRGB_SSE3(std::byte* dest, const std::byte* src, const size_t widt
  *
  * @param dest A pointer to destination image.
  * @param src A pointer to source image.
- * @param height The height of the source image.
  * @param width The width of the source image.
+ * @param height The height of the source image.
  * @param destCols Ihe width of the destination image.
  */
 void blitRGBtoRGBA_SSE3(std::byte* dest, const std::byte* src, const size_t width, const size_t height, const size_t destCols);

--- a/txtratl/include/txtratl/imagerect.hpp
+++ b/txtratl/include/txtratl/imagerect.hpp
@@ -8,9 +8,7 @@
 namespace txtratl
 {
 
-/**
- *  @brief Class that holds all the data for an image to be packed into atlas.
- */
+ /// Holds all the data for an image to be packed into atlas.
 class ImageRect
 {
 public:

--- a/txtratl/include/txtratl/imagerect.hpp
+++ b/txtratl/include/txtratl/imagerect.hpp
@@ -3,12 +3,13 @@
 #include <filesystem>
 
 #include "txtratl/image.hpp"
+
 #include "rectpack2d/pack.h"
 
 namespace txtratl
 {
 
- /// Holds all the data for an image to be packed into atlas.
+/// Holds all the data for an image to be packed into atlas.
 class ImageRect
 {
 public:

--- a/txtratl/src/atlas.cpp
+++ b/txtratl/src/atlas.cpp
@@ -17,7 +17,7 @@
 namespace txtratl
 {
 
-class Atlas::ImageRectImpl
+class Atlas::ImageRectImpl final
 {
 public:
     using ImageRects = std::vector<ImageRect>;
@@ -48,14 +48,12 @@ Atlas& Atlas::operator=(Atlas rhs)
     return *this;
 }
 
-bool Atlas::blitImages(Image& canvas) const
+void Atlas::blitImages(Image& canvas) const
 {
     for (auto& imagerect : mImpl->rects())
     {
         canvas.blitImage(imagerect.image(), imagerect.x(), imagerect.y());
     }
-
-    return true;
 }
 
 bool Atlas::writeMetadata(const std::filesystem::path& outputFilepath) const
@@ -84,10 +82,9 @@ bool Atlas::writeMetadata(const std::filesystem::path& outputFilepath) const
     return true;
 }
 
-bool Atlas::addImage(const std::filesystem::path& filepath)
+void Atlas::addImage(const std::filesystem::path& filepath)
 {
     mImpl->rects().emplace_back(ImageRect(filepath));
-    return true;
 }
 
 bool Atlas::packImages()
@@ -116,7 +113,7 @@ bool Atlas::packImages()
         return false;
     }
 
-    // Update the size of the target atlas
+    // Update the size of the target atlas.
     mWidth = static_cast<size_t>(bins[0].size.w);
     mHeight = static_cast<size_t>(bins[0].size.h);
 
@@ -125,16 +122,13 @@ bool Atlas::packImages()
 
 bool Atlas::createAtlas(const std::filesystem::path& imageFilepath, const std::filesystem::path& metadataFilepath)
 {
-    // Create an empty image for atlas
+    // Create an empty image for atlas.
     auto canvas = Image(mHeight, mWidth, 4);
 
-    // Blit images into atlas image according to rect coordinates decided by packing
-    if (!blitImages(canvas))
-    {
-        return false;
-    }
+    // Blits the images into an atlas image according to rect coordinates decided by packing.
+    blitImages(canvas);
 
-    // Write the atlas image into the destionation file
+    // Write the atlas image file and release the data from memory.
     canvas.save(imageFilepath);
     canvas.release();
 

--- a/txtratl/src/atlas.cpp
+++ b/txtratl/src/atlas.cpp
@@ -1,10 +1,5 @@
-#include <algorithm>
-#include <cstdio>
-#include <cstring>
 #include <fstream>
 #include <iostream>
-#include <ostream>
-#include <stdexcept>
 #include <vector>
 
 #include "txtratl/atlas.hpp"

--- a/txtratl/src/atlas.cpp
+++ b/txtratl/src/atlas.cpp
@@ -52,7 +52,7 @@ void Atlas::blitImages(Image& canvas) const
 {
     for (auto& imagerect : mImpl->rects())
     {
-        canvas.blitImage(imagerect.image(), imagerect.x(), imagerect.y());
+        canvas.blitImage(imagerect.image(), imagerect.x(), imagerect.y(), true);
     }
 }
 

--- a/txtratl/src/image.cpp
+++ b/txtratl/src/image.cpp
@@ -43,7 +43,13 @@ std::byte* Image::data(size_t x, size_t y, size_t channel) const
         return nullptr;
     }
 
-    size_t offset = y * mWidth * mChannels + x * mChannels + channel;
+    const size_t offset = y * mWidth * mChannels + x * mChannels + channel;
+
+    if (offset >= (*mData).size())
+    {
+        throw std::out_of_range("Out of bounds access to image data.");
+    }
+
     return (*mData).data() + offset;
 }
 

--- a/txtratl/src/image.cpp
+++ b/txtratl/src/image.cpp
@@ -28,7 +28,7 @@ void Image::allocate(size_t width, size_t height, size_t channels)
     mWidth = width;
     mHeight = height;
     mChannels = channels;
-    mData = std::make_shared<std::vector<uint8_t>>(mWidth * mHeight * mChannels);
+    mData = std::make_shared<std::vector<std::byte>>(mWidth * mHeight * mChannels);
 }
 
 void Image::load()
@@ -36,7 +36,7 @@ void Image::load()
     load(mFilePath);
 }
 
-uint8_t* Image::data(size_t x, size_t y, size_t channel) const
+std::byte* Image::data(size_t x, size_t y, size_t channel) const
 {
     if (!mData)
     {

--- a/txtratl/src/image.cpp
+++ b/txtratl/src/image.cpp
@@ -65,12 +65,9 @@ size_t Image::width() const
 void Image::release()
 {
     mData = nullptr;
-    mChannels = 0;
-    mHeight = 0;
-    mWidth = 0;
 }
 
-void Image::blitImage(const Image& source, size_t x, size_t y)
+void Image::blitImage(const Image& source, size_t x, size_t y, bool releaseAfterUse)
 {
     // If the image data has not been loaded, do it now.
     if (!source.data(0, 0, 0))
@@ -120,6 +117,11 @@ void Image::blitImage(const Image& source, size_t x, size_t y)
             }
         }
 #endif
+    }
+
+    if (releaseAfterUse)
+    {
+        const_cast<Image&>(source).release();
     }
 }
 

--- a/txtratl/src/image.cpp
+++ b/txtratl/src/image.cpp
@@ -93,8 +93,8 @@ void Image::blitImage(const Image& source, size_t x, size_t y)
         // Convert source from RGB to RGBA format.
         blitRGBtoRGBA_SSE3(data(x, y, 0),
                            source.data(0, 0, 0),
-                           source.height(),
                            source.width(),
+                           source.height(),
                            width());
     }
     else if (source.channels() == 4 && channels() == 3)
@@ -103,8 +103,8 @@ void Image::blitImage(const Image& source, size_t x, size_t y)
         // Convert source from RGBA to RGB format.
         blitRGBAtoRGB_SSE3(data(x, y, 0),
                            source.data(0, 0, 0),
-                           source.height(),
                            source.width(),
+                           source.height(),
                            width());
 #else
         // Convert source from RGBA to RGB format

--- a/txtratl/src/image_stb.cpp
+++ b/txtratl/src/image_stb.cpp
@@ -6,7 +6,7 @@
 #include "txtratl/image.hpp"
 
 // Including stb_image and stb_image_write generates a plenty of compiler warnings.
-// Ignore those warnings when including these headers to allow project to have high level of warnings enabled. 
+// Ignore those warnings when including these headers to allow project to have high level of warnings enabled.
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4365 4820 4996 5045 5219 5262)
@@ -75,9 +75,13 @@ void Image::load(const std::filesystem::path& filepath)
 
 void Image::save(const std::filesystem::path& filepath) const
 {
-    if (!stbi_write_png(filepath.string().c_str(), static_cast<int>(mWidth), static_cast<int>(mHeight), static_cast<int>(mChannels), (*mData).data(), static_cast<int>(mWidth * mChannels)))
+    if (stbi_write_png(filepath.string().c_str(),
+                       static_cast<int>(mWidth), static_cast<int>(mHeight), static_cast<int>(mChannels),
+                       (*mData).data(), static_cast<int>(mWidth * mChannels)) != 1)
     {
-
+        std::string msg = "Failed to save file '" + filepath.string() + "': ";
+        msg += stbi_failure_reason();
+        throw std::runtime_error(msg);
     }
 }
 

--- a/txtratl/src/image_stb.cpp
+++ b/txtratl/src/image_stb.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <stdexcept>
@@ -56,7 +57,7 @@ void Image::load(const std::filesystem::path& filepath)
     auto height = 0;
     auto channels = 0;
 
-    uint8_t* buffer = stbi_load(filepath.string().c_str(), &width, &height, &channels, 0);
+    auto buffer = stbi_load(filepath.string().c_str(), &width, &height, &channels, 0);
 
     if (!buffer)
     {

--- a/txtratl/src/image_stb.cpp
+++ b/txtratl/src/image_stb.cpp
@@ -74,7 +74,10 @@ void Image::load(const std::filesystem::path& filepath)
 
 void Image::save(const std::filesystem::path& filepath) const
 {
-    stbi_write_png(filepath.string().c_str(), static_cast<int>(mWidth), static_cast<int>(mHeight), static_cast<int>(mChannels), (*mData).data(), static_cast<int>(mWidth * mChannels));
+    if (!stbi_write_png(filepath.string().c_str(), static_cast<int>(mWidth), static_cast<int>(mHeight), static_cast<int>(mChannels), (*mData).data(), static_cast<int>(mWidth * mChannels)))
+    {
+
+    }
 }
 
 } // namespace txtratl

--- a/txtratl/src/imageblit.cpp
+++ b/txtratl/src/imageblit.cpp
@@ -11,24 +11,26 @@
 namespace txtratl
 {
 
-void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t rows, const size_t cols, const size_t destCols)
+void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destinationWidth)
 {
+    const size_t destinationPixelBytes = 3;
+
     // A mask for skipping the every fourth byte out of 16 bytes.
     const int8_t maskBytes[16] = {0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, -1, -1, -1, -1};
     __m128i mask = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(&maskBytes));
 
-    size_t endPixels = cols % 4;
+    size_t endPixels = width % 4;
     if (!endPixels)
     {
         endPixels = 4;
     }
 
-    for (size_t row = 0; row < rows; ++row)
+    for (size_t row = 0; row < height; ++row)
     {
-        uint8_t* destRow = dest + row * destCols* 3;
+        uint8_t* destRow = dest + row * destinationWidth * destinationPixelBytes;
 
         // Copy bytes in 16 byte (4 pixel) chunks, skip the last 4-16 bytes.
-        const uint8_t* end = src + (cols - endPixels) * 4;
+        const uint8_t* end = src + (width - endPixels) * 4;
         for (; src < end; src += 16, destRow += 12)
         {
             _mm_storeu_si128(reinterpret_cast<__m128i*>(destRow), _mm_shuffle_epi8(_mm_lddqu_si128(reinterpret_cast<const __m128i*>(src)), mask));
@@ -37,15 +39,17 @@ void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t rows, co
         // Copy the remaining bytes manually to avoid:
         //     1) out-of-bounds access if there's less than 16 bytes available,
         //     2) adding an extra pixel to the dest (16 byte stores and max 12 bytes of data).
-        for (size_t i = 0; i < endPixels; src += 4, destRow += 3, ++i)
+        for (size_t i = 0; i < endPixels; src += 4, destRow += destinationPixelBytes, ++i)
         {
-            std::memcpy(destRow, src, 3);
+            std::memcpy(destRow, src, destinationPixelBytes);
         }
     }
 }
 
-void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t rows, const size_t cols, const size_t destCols)
+void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destinationWidth)
 {
+    const size_t destinationPixelBytes = 4;
+
     // Mask for shuffling 24-bit RGB bytes into 32-bit RGBA sets.
     const int8_t maskBytes[16] = {0, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8, -1, 9, 10, 11, -1};
     __m128i mask = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(&maskBytes));
@@ -55,14 +59,14 @@ void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t rows, co
     __m128i orMask = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(&orMaskBytes));
 
     // Number of pixels at the end of every row that won't fill a 128-bit XMM register
-    const size_t endPixels = cols % 4;
+    const size_t endPixels = width % 4;
 
-    for (size_t row = 0; row < rows; ++row)
+    for (size_t row = 0; row < height; ++row)
     {
-        uint8_t* destRow = (dest + row * destCols * 4);
+        uint8_t* destRow = (dest + row * destinationWidth * destinationPixelBytes);
 
         // Copy bytes in 12 byte (4 pixel) chunks
-        const uint8_t* end = src + (cols - endPixels) * 3;
+        const uint8_t* end = src + (width - endPixels) * 3;
         for (; src < end; src += 12, destRow += 16)
         {
             __m128i bytes = _mm_shuffle_epi8(_mm_lddqu_si128(reinterpret_cast<const __m128i*>(src)), mask);
@@ -71,10 +75,11 @@ void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t rows, co
         }
 
         // Copy the remaining bytes of the row manually if there are less than 4 pixels left
-        for (size_t i = 0; i < endPixels; src += 3, destRow += 4, ++i)
+        for (size_t i = 0; i < endPixels; src += 3, destRow += destinationPixelBytes, ++i)
         {
             uint32_t* d = reinterpret_cast<uint32_t*>(destRow);
             // Little endian, but doesn't matter as this function is for SSE3 :)
+            // Set alpha to 0xff.
             *d = static_cast<uint32_t>((0xff << 24) | (*(src + 2) << 16) | (*(src + 1) << 8) | *(src));
         }
     }

--- a/txtratl/src/imageblit.cpp
+++ b/txtratl/src/imageblit.cpp
@@ -13,6 +13,7 @@ namespace txtratl
 
 void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destinationWidth)
 {
+    const size_t sourcePixelBytes = 4;
     const size_t destinationPixelBytes = 3;
 
     // A mask for skipping the every fourth byte out of 16 bytes.
@@ -30,7 +31,7 @@ void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, c
         uint8_t* destRow = dest + row * destinationWidth * destinationPixelBytes;
 
         // Copy bytes in 16 byte (4 pixel) chunks, skip the last 4-16 bytes.
-        const uint8_t* end = src + (width - endPixels) * 4;
+        const uint8_t* end = src + (width - endPixels) * sourcePixelBytes;
         for (; src < end; src += 16, destRow += 12)
         {
             _mm_storeu_si128(reinterpret_cast<__m128i*>(destRow), _mm_shuffle_epi8(_mm_lddqu_si128(reinterpret_cast<const __m128i*>(src)), mask));
@@ -39,7 +40,7 @@ void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, c
         // Copy the remaining bytes manually to avoid:
         //     1) out-of-bounds access if there's less than 16 bytes available,
         //     2) adding an extra pixel to the dest (16 byte stores and max 12 bytes of data).
-        for (size_t i = 0; i < endPixels; src += 4, destRow += destinationPixelBytes, ++i)
+        for (size_t i = 0; i < endPixels; src += sourcePixelBytes, destRow += destinationPixelBytes, ++i)
         {
             std::memcpy(destRow, src, destinationPixelBytes);
         }
@@ -48,6 +49,7 @@ void blitRGBAtoRGB_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, c
 
 void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, const size_t height, const size_t destinationWidth)
 {
+    const size_t sourcePixelBytes = 3;
     const size_t destinationPixelBytes = 4;
 
     // Mask for shuffling 24-bit RGB bytes into 32-bit RGBA sets.
@@ -66,7 +68,7 @@ void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, c
         uint8_t* destRow = (dest + row * destinationWidth * destinationPixelBytes);
 
         // Copy bytes in 12 byte (4 pixel) chunks
-        const uint8_t* end = src + (width - endPixels) * 3;
+        const uint8_t* end = src + (width - endPixels) * sourcePixelBytes;
         for (; src < end; src += 12, destRow += 16)
         {
             __m128i bytes = _mm_shuffle_epi8(_mm_lddqu_si128(reinterpret_cast<const __m128i*>(src)), mask);
@@ -75,7 +77,7 @@ void blitRGBtoRGBA_SSE3(uint8_t* dest, const uint8_t* src, const size_t width, c
         }
 
         // Copy the remaining bytes of the row manually if there are less than 4 pixels left
-        for (size_t i = 0; i < endPixels; src += 3, destRow += destinationPixelBytes, ++i)
+        for (size_t i = 0; i < endPixels; src += sourcePixelBytes, destRow += destinationPixelBytes, ++i)
         {
             uint32_t* d = reinterpret_cast<uint32_t*>(destRow);
             // Little endian, but doesn't matter as this function is for SSE3 :)


### PR DESCRIPTION
* Changed image data type from `uint8_t` to `std::byte`.
* Added exceptions to Image access functions.
* Fixed the order if width, height parameters in blitting functions.
* Removed `@Brief` tags.
* Updated doxygen documentation.